### PR TITLE
T5 support and generalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ transformers](https://huggingface.co/docs/transformers/en/index).
 ## Philosophy
 
 Yoyodyne Pre-trained inherits many of the same features as Yoyodyne itself, but
-the only supported architecture consists of a pre-trained transformer encoder
-and a pre-trained transformer decoder with a randomly-initialized
-cross-attention (à la Rothe et al. 2020). Because these modules are pre-trained,
-there are few architectural hyperparameters to set once one has determined which
-encoder and decoder to warm-start from. To keep Yoyodyne as simple as possible,
-Yoyodyne Pre-trained is a separate library though it has many of the same
-features and interfaces.
+limits itself to two types of pre-trained transformers:
+
+-   a pre-trained transformer encoder and a pre-trained transformer decoder with
+    a randomly-initialized cross-attention (à la Rothe et al. 2020)
+-   a T5 model
+
+Because these modules are pre-trained, there are few architectural
+hyperparameters to set once one has determined which encoder and decoder to
+warm-start from. To keep Yoyodyne as simple as possible, Yoyodyne Pre-trained is
+a separate library though it has many of the same features and interfaces.
 
 ## Installation
 
@@ -73,22 +76,28 @@ experiment.
 
 #### Model architecture
 
-Most of the details of the model architecture are determined by the choice of
-pre-trained encoder and decoder, specified either as the names used on Hugging
-Face or a local path. By default, Yoyodyne Pre-trained uses multilingual cased
-BERT modules but has also been tested with XLM-RoBERTa.
+##### Encoder-decoder models
 
-While it is possible to use separate encoder and decoder modules from separate
-sources, in practice it is usually wise to use the same model and furthermore to
-to tie their parameters, as in the following YAML snippet.
+In practice it is usually wise to tie the encoder and decoder parameters, as in
+the following YAML snippet:
 
     ...
     model:
-      encoder:
-      encoder: google-bert/bert-base-multilingual-cased
-      decoder: google-bert/bert-base-multilingual-cased
-      tie_encoder_decoder: true
-      ...
+      class_path: yoyodyne_pretrained.models.EncoderDecoderModel
+      init_args:
+        model_name: google-bert/bert-base-multilingual-cased
+        tie_encoder_decoder: true
+        ...
+
+##### T5 models
+
+The following snippet shows a simple configuration T5 configuration using ByT5:
+
+      class_path: yoyodyne_pretrained.models.T5Model
+      init_args:
+        model_name: google/byt5-base
+        tie_encoder_decoder: true
+        ...
 
 #### Optimization
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,10 +1,8 @@
 The files in this directory are example YAML configuration files showing
 Yoyodyne's use with various pre-trained encoders.
 
-Since the model builds its own cross-attention, it is possible to mix and match
-encoders and decoders. We are currently recommending the use of multilingual BERT, with or without parameter-tying.
-
 Pre-trained encoders:
 
+-   [byT5 (`google/byt5-base`)](https://huggingface.co/google/byt5-base)
 -   [mBERT
     (`google-bert/bert-base-multilingual-cased`)](https://huggingface.co/google-bert/bert-base-multilingual-cased)

--- a/configs/byt5.yaml
+++ b/configs/byt5.yaml
@@ -20,13 +20,12 @@ trainer:
       init_args:
         project: unit1
         save_dir: /Users/Shinji/mbert/models
-
 model:
-  class_path: yoyodyne_pretrained.models.EncoderDecoderModel 
+  class_path: yoyodyne_pretrained.models.T5Model
   init_args:
     dropout: 0.4093681744748403
     label_smoothing: 0.14915316576243975
-    model_name: google-bert/bert-base-multilingual-cased
+    model_name: google/byt5-base
     optimizer:
       class_path: torch.optim.Adam
       init_args:
@@ -35,9 +34,8 @@ model:
       class_path: yoyodyne_pretrained.schedulers.WarmupInverseSquareRoot
       init_args:
         warmup_epochs: 2
-    tie_encoder_decoder: false
 data:
-  batch_size: 32
+  batch_size: 448
   features_col: 3
   train: /Users/Shinji/conll2017/data/english-train-medium
   val: /Users/Shinji/conll2017/data/english-train-medium

--- a/configs/mbert_tied.yaml
+++ b/configs/mbert_tied.yaml
@@ -21,19 +21,20 @@ trainer:
         project: unit1
         save_dir: /Users/Shinji/mbert/models
 model:
-  decoder: google-bert/bert-base-multilingual-cased
-  encoder: google-bert/bert-base-multilingual-cased
-  tie_encoder_decoder: true
-  dropout: 0.4842384076860544
-  label_smoothing: 0.1337104241885073
-  optimizer:
-    class_path: torch.optim.Adam
-    init_args:
-      lr: 0.0007555117338671614
-  scheduler:
-    class_path: yoyodyne_pretrained.schedulers.WarmupInverseSquareRoot
-    init_args:
-      warmup_epochs: 31
+  class_path: yoyodyne_pretrained.models.EncoderDecoderModel 
+  init_args:
+    dropout: 0.4093681744748403
+    label_smoothing: 0.14915316576243975
+    model_name: google-bert/bert-base-multilingual-cased
+    optimizer:
+      class_path: torch.optim.Adam
+      init_args:
+        lr: 3.5137129343414837e-05
+    scheduler:
+      class_path: yoyodyne_pretrained.schedulers.WarmupInverseSquareRoot
+      init_args:
+        warmup_epochs: 2
+    tie_encoder_decoder: true
 data:
   batch_size: 448
   features_col: 3

--- a/examples/wandb_sweeps/configs/mbert_grid.yaml
+++ b/examples/wandb_sweeps/configs/mbert_grid.yaml
@@ -3,29 +3,29 @@ metric:
   name: val_accuracy
   goal: maximize
 parameters:
-  model.dropout:
+  model.class_path:
+    value: yoyodyne_pretrained.models.EncoderDecoderModel
+  model.init_args.dropout:
     distribution: uniform
     min: 0
     max: 0.5
-  model.label_smoothing:
+  model.init_args.label_smoothing:
     distribution: uniform
     min: 0
     max: 0.2
-  model.encoder:
+  model.init_args.model_name:
     value: google-bert/bert-base-multilingual-cased 
-  model.decoder:
-    value: google-bert/bert-base-multilingual-cased 
-  model.tie_encoder_decoder:
+  model.init_args.tie_encoder_decoder:
     value: true
-  model.optimizer.class_path:
+  model.init_args.optimizer.class_path:
     value: torch.optim.Adam
-  model.optimizer.init_args.lr:
+  model.init_args.optimizer.init_args.lr:
     distribution: log_uniform_values
     min: 1e-06
     max: 0.001
-  model.scheduler.class_path:
+  model.init_args.scheduler.class_path:
     value: yoyodyne_pretrained.schedulers.WarmupInverseSquareRoot
-  model.scheduler.init_args.warmup_epochs:
+  model.init_args.scheduler.init_args.warmup_epochs:
     distribution: q_uniform
     q: 1
     min: 1

--- a/examples/wandb_sweeps/get_hyperparameters.py
+++ b/examples/wandb_sweeps/get_hyperparameters.py
@@ -56,7 +56,6 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "run_path",
-        help="Run path (in the form entity/project/run_id)"
+        "run_path", help="Run path (in the form entity/project/run_id)"
     )
     main(parser.parse_args())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yoyodyne-pretrained"
-version = "0.1.0"
+version = "0.1.1"
 description = "Small-vocabulary transformer sequence-to-sequence models with warm starts"
 license = { text = "Apache 2.0" }
 readme = "README.md"

--- a/tests/testdata/mbert_config.yaml
+++ b/tests/testdata/mbert_config.yaml
@@ -11,14 +11,15 @@ data:
   batch_size: 10  # 100 batches per epoch.
   features_col: 3
 model:
-  decoder: google-bert/bert-base-multilingual-cased
-  encoder: google-bert/bert-base-multilingual-cased
-  tie_encoder_decoder: true
-  optimizer:
-    class_path: torch.optim.Adam
-    init_args:
-      lr: 1e-4
-  scheduler:
-    class_path: yoyodyne_pretrained.schedulers.WarmupInverseSquareRoot
-    init_args:
-      warmup_epochs: 3
+  class_path: yoyodyne_pretrained.models.EncoderDecoderModel
+  init_args:
+    model_name: google-bert/bert-base-multilingual-cased
+    optimizer:
+      class_path: torch.optim.Adam
+      init_args:
+        lr: 1e-4
+    scheduler:
+      class_path: yoyodyne_pretrained.schedulers.WarmupInverseSquareRoot
+      init_args:
+        warmup_epochs: 3
+    tie_encoder_decoder: true

--- a/yoyodyne-pretrained.bib
+++ b/yoyodyne-pretrained.bib
@@ -19,3 +19,19 @@
     title = {Unsupervised cross-lingual representation learning at scale},
     booktitle = {Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics},
     pages = {8440-8451}}
+
+@article{Raffel:EtAl:20,
+    author = {Raffel, Colin and Shazeer, Noam and Roberts, Adam and Lee, Katherine and Narang, Sharan and Matena, Michael and \ldots and Liu, Peter J.},
+    year = {2020},
+    title = {Exploring the limits of transfer learning with a unified text-to-text transformer},
+    journal = {Journal of Machine Learning Research},
+    volume = {21},
+    pages = {1-67}}
+
+@article{Xue:EtAl:22,
+    author = {Xue, Linting and Barua, Aditya and Constant, Noah and Al-Rfou, Rami and Narang, Sharan and Kale, Mihir and \ldots Raffel, Colin},
+    year = {2022},
+    title = {{ByT5}: Towards a token-free future with pre-trained byte-to-byte models},
+    journal = {Transactions of the Association for Computational Linguistics},
+    volume = {10},
+    pages = {291-306}}

--- a/yoyodyne_pretrained/cli.py
+++ b/yoyodyne_pretrained/cli.py
@@ -12,6 +12,7 @@ def yoyodyne_pretrained_python_interface(args: cli.ArgsType = None):
     YoyodynePretrainedCLI(
         models.PretrainedModel,
         data.DataModule,
+        subclass_mode_model=True,
         # Prevents prediction logits from accumulating in memory; see the
         # documentation in `trainers.py` for more context.
         trainer_class=trainers.Trainer,
@@ -38,6 +39,7 @@ class YoyodynePretrainedCLI(cli.LightningCLI):
             "prediction",
             required=False,
         )
+        parser.link_arguments("model.init_args.model_name", "data.model_name")
 
 
 def main() -> None:
@@ -46,9 +48,11 @@ def main() -> None:
         datefmt="%d-%b-%y %H:%M:%S",
         level="INFO",
     )
+    # Select the model.
     YoyodynePretrainedCLI(
-        models.PretrainedModel,
-        data.DataModule,
+        model_class=models.BaseModel,
+        datamodule_class=data.DataModule,
+        subclass_mode_model=True,
         # Prevents prediction logits from accumulating in memory; see the
         # documentation in `trainers.py` for more context.
         trainer_class=trainers.Trainer,

--- a/yoyodyne_pretrained/data/collators.py
+++ b/yoyodyne_pretrained/data/collators.py
@@ -11,16 +11,15 @@ from . import batches, tsv
 class Collator:
     """Collator for text data."""
 
-    source_tokenizer: transformers.AutoTokenizer
-    target_tokenizer: transformers.AutoTokenizer | None
+    tokenizer: transformers.AutoTokenizer
 
     def __call__(self, itemlist: list[tsv.SampleType]) -> batches.Batch:
         source, target = zip(*itemlist)
-        encoding = self.source_tokenizer(
+        encoding = self.tokenizer(
             source, padding="longest", return_tensors="pt"
         )
         if target:
-            decoding = self.target_tokenizer(
+            decoding = self.tokenizer(
                 target, padding="longest", return_tensors="pt"
             )
             return batches.Batch(

--- a/yoyodyne_pretrained/defaults.py
+++ b/yoyodyne_pretrained/defaults.py
@@ -21,8 +21,6 @@ LABEL_SMOOTHING = 0.0
 NUM_BEAMS = 5
 
 # Architecture arguments.
-DECODER = "google-bert/bert-base-multilingual-cased"
-ENCODER = "google-bert/bert-base-multilingual-cased"
 TIE_ENCODER_DECODER = True
 
 # Optimizer options.

--- a/yoyodyne_pretrained/models.py
+++ b/yoyodyne_pretrained/models.py
@@ -3,101 +3,29 @@
 import lightning
 from lightning.pytorch import cli
 import torch
-from torch import nn, optim
+from torch import optim
 import transformers
 
 from . import data, defaults, metrics
 
 
-class PretrainedModel(lightning.LightningModule):
-    """Yoyodyne pretrained model.
+class BaseModel(lightning.LightningModule):
+    """Model base class.
 
-    This model consists of a pretrained encoder and decoder with randomly
-    initialized cross-attention.
-
-    After:
-        Rothe, S., Narayan, S., and Severyn, A. 2020. Leveraging pre-trained
-        checkpoints for sequence generation tasks. Transactions of the
-        Association for Computational Linguistics 8: 264-280.
-
-    * The forward method returns a tensor of shape B x vocab_size x seq_length
-      for compatibility with loss and evaluation functions.
+    * The forward method returns a loss tensor.
     * Cross-entropy loss is the loss function.
     * One or more predictions tensor(s) are returned by predict_step.
     * Loss is returned by training_step.
     * Evaluation metrics are tracked by test_step; nothing is returned.
     * Validation loss and evaluation metrics are tracked by validation_step;
       nothing is returned.
-
-    Args:
-        dropout: Dropout probability.
-        label_smoothing: Label smoothing probability.
-        encoder: Name of the Hugging Face encoder model.
-        decoder: Name of the Hugging Face decoder model.
-        tie_encoder_decoder: Should we tie the encoder and decoder?
-        num_beams: Width of the beam to use during decoding.
     """
 
-    model: transformers.EncoderDecoderModel
-    loss_func: nn.CrossEntropyLoss
     # TODO: update with new metrics as they become available.
     accuracy: metrics.Accuracy | None
     generation_config: transformers.GenerationConfig
     optimizer: optim.Optimizer
     scheduler: optim.lr_scheduler.LRScheduler
-
-    def __init__(
-        self,
-        dropout=defaults.DROPOUT,
-        label_smoothing=defaults.LABEL_SMOOTHING,
-        encoder=defaults.ENCODER,
-        decoder=defaults.DECODER,
-        tie_encoder_decoder=defaults.TIE_ENCODER_DECODER,
-        num_beams=defaults.NUM_BEAMS,
-        compute_accuracy=True,
-        optimizer: cli.OptimizerCallable = defaults.OPTIMIZER,
-        scheduler: cli.LRSchedulerCallable = defaults.SCHEDULER,
-    ):
-        super().__init__()
-        # Needed for various attributes.
-        self.model = (
-            transformers.EncoderDecoderModel.from_encoder_decoder_pretrained(
-                encoder,
-                decoder,
-                tie_encoder_decoder=tie_encoder_decoder,
-                encoder_hidden_dropout_prob=dropout,
-                decoder_hidden_dropout_prob=dropout,
-            )
-        )
-        # Necessary patching for decoding.
-        decoder_tokenizer = transformers.AutoTokenizer.from_pretrained(decoder)
-        bos = decoder_tokenizer.cls_token_id
-        eos = decoder_tokenizer.sep_token_id
-        pad = decoder_tokenizer.pad_token_id
-        self.model.config.decoder_start_token_id = bos
-        self.model.config.bos_token_id = bos
-        self.model.config.eos_token_id = eos
-        self.model.config.pad_token_id = pad
-        target_vocab_size = (
-            self.model.get_decoder().get_output_embeddings().out_features
-        )
-        self.accuracy = (
-            metrics.Accuracy(ignore_index=pad, num_classes=target_vocab_size)
-            if compute_accuracy
-            else None
-        )
-        self.generation_config = transformers.GenerationConfig(
-            decoder_start_token_id=bos,
-            bos_token_id=bos,
-            eos_token_id=eos,
-            pad_token_id=pad,
-            early_stopping=True,
-            num_beams=num_beams,
-        )
-        # Actually initialized by configure_optimizers.
-        self.optimizer = optimizer
-        self.scheduler = scheduler
-        self.save_hyperparameters()
 
     def configure_optimizers(
         self,
@@ -180,3 +108,141 @@ class PretrainedModel(lightning.LightningModule):
             attention_mask=source_mask,
             generation_config=self.generation_config,
         )
+
+
+class EncoderDecoderModel(BaseModel):
+    """Pretrained encoder/decoder.
+
+    This model consists of a pretrained encoder and decoder with randomly
+    initialized cross-attention.
+
+    After:
+        Rothe, S., Narayan, S., and Severyn, A. 2020. Leveraging pre-trained
+        checkpoints for sequence generation tasks. Transactions of the
+        Association for Computational Linguistics 8: 264-280.
+
+    Args:
+        encoder: Name of the Hugging Face encoder model.
+        decoder: Name of the Hugging Face decoder model.
+        dropout: Dropout probability.
+        label_smoothing: Label smoothing probability.
+        num_beams: Width of the beam to use during decoding.
+    """
+
+    model: transformers.EncoderDecoderModel
+
+    def __init__(
+        self,
+        *,
+        model_name="google-bert/bert-base-multilingual-cased",
+        dropout=defaults.DROPOUT,
+        label_smoothing=defaults.LABEL_SMOOTHING,
+        tie_encoder_decoder=defaults.TIE_ENCODER_DECODER,
+        num_beams=defaults.NUM_BEAMS,
+        compute_accuracy=True,
+        optimizer: cli.OptimizerCallable = defaults.OPTIMIZER,
+        scheduler: cli.LRSchedulerCallable = defaults.SCHEDULER,
+    ):
+        super().__init__()
+        self.model = (
+            transformers.EncoderDecoderModel.from_encoder_decoder_pretrained(
+                model_name,
+                model_name,
+                tie_encoder_decoder=tie_encoder_decoder,
+                encoder_hidden_dropout_prob=dropout,
+                decoder_hidden_dropout_prob=dropout,
+            )
+        )
+        # Necessary patching for decoding.
+        tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
+        bos = tokenizer.cls_token_id
+        eos = tokenizer.sep_token_id
+        pad = tokenizer.pad_token_id
+        self.model.config.decoder_start_token_id = bos
+        self.model.config.bos_token_id = bos
+        self.model.config.eos_token_id = eos
+        self.model.config.pad_token_id = pad
+        target_vocab_size = (
+            self.model.get_decoder().get_output_embeddings().out_features
+        )
+        self.accuracy = (
+            metrics.Accuracy(ignore_index=pad, num_classes=target_vocab_size)
+            if compute_accuracy
+            else None
+        )
+        self.generation_config = transformers.GenerationConfig(
+            decoder_start_token_id=bos,
+            bos_token_id=bos,
+            eos_token_id=eos,
+            pad_token_id=pad,
+            early_stopping=True,
+            num_beams=num_beams,
+        )
+        # Actually initialized by configure_optimizers.
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.save_hyperparameters()
+
+
+class T5Model(BaseModel):
+    """T5 model (usually mT5 or ByT5).
+
+    After:
+        Raffel, C., Shazeer, N. M., Roberts, A., Lee, K., Narang, S., Matena,
+        M., ..., and Liu, P. J. 2020. Exploring the limits of transfer
+        learning with a unified text-to-text transformer. Journal of Machine
+        Learning Research 21: 1-67.
+
+    Args:
+        dropout: Dropout probability.
+        label_smoothing: Label smoothing probability.
+        model_name: Name of the Hugging Face T5 model.
+        num_beams: Width of the beam to use during decoding.
+    """
+
+    model: transformers.T5ForConditionalGeneration
+
+    def __init__(
+        self,
+        *,
+        model_name="google/byt5-base",
+        dropout=defaults.DROPOUT,
+        label_smoothing=defaults.LABEL_SMOOTHING,
+        num_beams=defaults.NUM_BEAMS,
+        compute_accuracy=True,
+        optimizer: cli.OptimizerCallable = defaults.OPTIMIZER,
+        scheduler: cli.LRSchedulerCallable = defaults.SCHEDULER,
+    ):
+        super().__init__()
+        self.model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+            model_name, dropout_rate=dropout
+        )
+        # BOS is apparently not used.
+        eos = self.model.config.eos_token_id
+        pad = self.model.config.pad_token_id
+        self.model.config.decoder_start_token_id = pad
+        target_vocab_size = self.model.get_decoder().embed_tokens.embedding_dim
+        self.accuracy = (
+            metrics.Accuracy(ignore_index=pad, num_classes=target_vocab_size)
+            if compute_accuracy
+            else None
+        )
+        self.generation_config = transformers.GenerationConfig(
+            decoder_start_token_id=pad,
+            eos_token_id=eos,
+            pad_token_id=pad,
+            early_stopping=True,
+            num_beams=num_beams,
+        )
+        # Actually initialized by configure_optimizers.
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.save_hyperparameters()
+
+    # Overrides to discard the leading BOS in the POS. Thsi is harmless for
+    # prediction.
+
+    def _decode(
+        self, source: torch.Tensor, source_mask: torch.Tensor
+    ) -> torch.Tensor:
+        return super()._decode(source, source_mask)[:, 1:]


### PR DESCRIPTION
This modifies the library to support two types of pretrained architectures: warm-start encoder-decoder models with a randomly initialized cross-attention (previously supported) as well as T5 models (with the focus being on ByT5). 