### PR TITLE
Fixes auto-config of loggers

### DIFF
--- a/configs/byt5.yaml
+++ b/configs/byt5.yaml
@@ -20,7 +20,7 @@ trainer:
       init_args:
         project: unit1
         save_dir: /Users/Shinji/mbert/models
-  precision: bf16-true
+  precision: bf16-mixed
 model:
   class_path: yoyodyne_pretrained.models.T5Model
   init_args:

--- a/configs/mbert_separate.yaml
+++ b/configs/mbert_separate.yaml
@@ -20,7 +20,7 @@ trainer:
       init_args:
         project: unit1
         save_dir: /Users/Shinji/mbert/models
-  precision: bf16-true
+  precision: bf16-mixed
 model:
   class_path: yoyodyne_pretrained.models.EncoderDecoderModel 
   init_args:

--- a/configs/mbert_tied.yaml
+++ b/configs/mbert_tied.yaml
@@ -20,7 +20,7 @@ trainer:
       init_args:
         project: unit1
         save_dir: /Users/Shinji/mbert/models
-  precision: bf16-true
+  precision: bf16-mixed
 model:
   class_path: yoyodyne_pretrained.models.EncoderDecoderModel 
   init_args:

--- a/examples/wandb_sweeps/README.md
+++ b/examples/wandb_sweeps/README.md
@@ -25,6 +25,8 @@ constants needed during the sweep, such as trainer arguments or data paths.
         configs/mbert_grid.yaml
     # Runs the sweep itself using hyperparameters from the the sweep and
     # additional fixed parameters from a Yoyodyne Pretrained config file.
+    # The --command argument tells the sweep to use Yoyodyne Pretrained rather
+    # than vanilla Yoyodyne.
     yoyodyne_sweep \
         --command "yoyodyne_pretrained" \
         --entity "${ENTITY}" \
@@ -59,8 +61,8 @@ the run's "Overview" on W&B, and then run:
     `--sweep_id`; arguments not being tuned should be passed using the
     `--config` file but note that hyperparameters set by the sweep will override
     those specified in the `--config`.
--   By default `random` and `bayes` search run indefinitely, until they are
-    killed. To specify a fixed number of samples, provide the `--count`
+-   By default search runs indefinitely, i.e., until the sweep command
+    terminates. To specify a fixed number of samples, provide the `--count`
     argument.
 -   For more information about W&B sweeps, [read
     here](https://docs.wandb.ai/guides/sweeps).

--- a/examples/wandb_sweeps/configs/byt5_grid.yaml
+++ b/examples/wandb_sweeps/configs/byt5_grid.yaml
@@ -1,4 +1,4 @@
-method: random
+method: bayes
 metric:
   name: val_accuracy
   goal: maximize
@@ -32,4 +32,4 @@ parameters:
     distribution: q_uniform
     q: 16
     min: 16
-    max: 1024
+    max: 512

--- a/examples/wandb_sweeps/configs/mbert_grid.yaml
+++ b/examples/wandb_sweeps/configs/mbert_grid.yaml
@@ -1,4 +1,4 @@
-method: random
+method: bayes
 metric:
   name: val_accuracy
   goal: maximize
@@ -34,4 +34,4 @@ parameters:
     distribution: q_uniform
     q: 16
     min: 16
-    max: 1024
+    max: 512

--- a/examples/wandb_sweeps/configs/tune.yaml
+++ b/examples/wandb_sweeps/configs/tune.yaml
@@ -1,4 +1,4 @@
-seed_everything: 1995
+seed_everything: 49
 trainer:
   max_epochs: 100
   max_time: 00:06:00:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yoyodyne-pretrained"
-version = "0.1.5"
+version = "0.1.6"
 description = "Small-vocabulary transformer sequence-to-sequence models with warm starts"
 license = { text = "Apache 2.0" }
 readme = "README.md"

--- a/yoyodyne_pretrained/cli.py
+++ b/yoyodyne_pretrained/cli.py
@@ -28,11 +28,6 @@ class YoyodynePretrainedCLI(cli.LightningCLI):
             required=False,
         )
         parser.link_arguments("model.init_args.model_name", "data.model_name")
-        parser.link_arguments(
-            "data.model_dir",
-            "trainer.logger.init_args.save_dir",
-            apply_on="instantiate",
-        )
 
 
 def main() -> None:
@@ -47,9 +42,6 @@ def main() -> None:
         datamodule_class=data.DataModule,
         subclass_mode_model=True,
         trainer_class=trainers.Trainer,
-        trainer_defaults={
-            "logger": {"class_path": "lightning.pytorch.loggers.CSVLogger"}
-        },
     )
 
 
@@ -60,8 +52,5 @@ def python_interface(args: cli.ArgsType = None) -> None:
         data.DataModule,
         subclass_mode_model=True,
         trainer_class=trainers.Trainer,
-        trainer_defaults={
-            "logger": {"class_path": "lightning.pytorch.loggers.CSVLogger"}
-        },
         args=args,
     )


### PR DESCRIPTION
In a previous revision I attempted to set things up so a CSV logger was always automatically configured. This does not play nice with W&B sweeps though: for reasons I don't fully undersatnd, it would:

1. rename every run in a sweep to "lightning_logs" after initialization
2. attempt and fail to write `config.yaml` to the same location, causing a failure on later runs.

I just disable this and document it.

Some minor drive-bys are done on sample config files as well.